### PR TITLE
Same record name with different namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ _Note:_ Currently [Treehugger](http://eed3si9n.com/treehugger/comments.html#Scal
 
 ##### Get the dependency with:
 
-    "com.julianpeeters" %% "avrohugger-core" % "1.3.0"
+    "com.julianpeeters" %% "avrohugger-core" % "1.3.1"
 
 
 ##### Description:
@@ -211,7 +211,7 @@ namespace rewritten. Multiple conflicting wildcards are not permitted.
 
 ##### Get the dependency with:
 
-    "com.julianpeeters" %% "avrohugger-filesorter" % "1.3.0"
+    "com.julianpeeters" %% "avrohugger-filesorter" % "1.3.1"
     
 
 ##### Description:
@@ -231,22 +231,22 @@ To ensure dependent schemas are compiled in the proper order (thus avoiding `org
 #### `avrohugger-tools`
 
 
-  Download the avrohugger-tools jar for Scala [2.12](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.12/1.3.0/avrohugger-tools_2.12-1.3.0-assembly.jar), or Scala [2.13](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.13/1.3.0/avrohugger-tools_2.13-1.3.0-assembly.jar) (>30MB!) and use it like the avro-tools jar `Usage: [-string] (schema|protocol|datafile) input... outputdir`:
+  Download the avrohugger-tools jar for Scala [2.12](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.12/1.3.1/avrohugger-tools_2.12-1.3.1-assembly.jar), or Scala [2.13](https://search.maven.org/remotecontent?filepath=com/julianpeeters/avrohugger-tools_2.13/1.3.1/avrohugger-tools_2.13-1.3.1-assembly.jar) (>30MB!) and use it like the avro-tools jar `Usage: [-string] (schema|protocol|datafile) input... outputdir`:
 
 
 * `generate` generates Scala case class definitions:
 
-`java -jar /path/to/avrohugger-tools_2.12-1.3.0-assembly.jar generate schema user.avsc . `
+`java -jar /path/to/avrohugger-tools_2.12-1.3.1-assembly.jar generate schema user.avsc . `
 
 
 * `generate-specific` generates definitions that extend Avro's `SpecificRecordBase`:
 
-`java -jar /path/to/avrohugger-tools_2.12-1.3.0-assembly.jar generate-specific schema user.avsc . `
+`java -jar /path/to/avrohugger-tools_2.12-1.3.1-assembly.jar generate-specific schema user.avsc . `
 
 
 * `generate-scavro` generates definitions that extend Scavro's `AvroSerializable`:
 
-`java -jar /path/to/avrohugger-tools_2.12-1.3.0-assembly.jar generate-scavro schema user.avsc . `
+`java -jar /path/to/avrohugger-tools_2.12-1.3.1-assembly.jar generate-scavro schema user.avsc . `
 
 
 ## Warnings

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -66,7 +66,7 @@ class TypeMatcher(
           }
         case Schema.Type.FIXED    => classStore.generatedClasses(schema)
         case Schema.Type.BYTES    => CustomTypeMatcher.checkCustomDecimalType(avroScalaTypes.decimal, schema)
-        case Schema.Type.RECORD   => classStore.generatedClasses(schema)
+        case Schema.Type.RECORD   => schema.getFullName
         case Schema.Type.ENUM     => CustomTypeMatcher.checkCustomEnumType(avroScalaTypes.`enum`, classStore, schema, useFullName)
         case Schema.Type.UNION    => {
           //unions are represented as shapeless.Coproduct

--- a/avrohugger-core/src/test/avro/SameRecordNameDifferentNamespace.avsc
+++ b/avrohugger-core/src/test/avro/SameRecordNameDifferentNamespace.avsc
@@ -1,0 +1,61 @@
+{
+  "type": "record",
+  "name": "Country",
+  "namespace": "com.countries",
+  "fields": [
+    {
+      "name": "key",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "paris",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "City",
+          "namespace": "com.europe",
+          "fields": [
+            {
+              "name": "key",
+              "type": "string",
+              "default": "Paris"
+            }
+          ]
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "london",
+      "type": [
+        "null",
+        "com.europe.City"
+      ],
+      "default": null
+    },
+    {
+      "name": "newYork",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "City",
+          "namespace": "com.america",
+          "fields": [
+            {
+              "name": "name",
+              "type": "string",
+              "default": "Paris"
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Defaults.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Defaults.scala
@@ -36,7 +36,7 @@ final object Embedded {
   }
 }
 
-final case class DefaultTest(suit: DefaultEnum.Value = DefaultEnum.SPADES, number: Int = 0, str: String = "str", optionString: Option[String] = None, optionStringValue: Option[String] = Some("default"), embedded: Embedded = new Embedded(1), defaultArray: Array[Int] = Array(1, 3, 4, 5), optionalEnum: Option[DefaultEnum.Value] = None, defaultMap: Map[String, String] = Map("Hello" -> "world", "Merry" -> "Christmas"), byt: Array[Byte] = Array[Byte](-61, -65)) extends AvroSerializeable with Defaults {
+final case class DefaultTest(suit: DefaultEnum.Value = DefaultEnum.SPADES, number: Int = 0, str: String = "str", optionString: Option[String] = None, optionStringValue: Option[String] = Some("default"), embedded: example.idl.Embedded = new Embedded(1), defaultArray: Array[Int] = Array(1, 3, 4, 5), optionalEnum: Option[DefaultEnum.Value] = None, defaultMap: Map[String, String] = Map("Hello" -> "world", "Merry" -> "Christmas"), byt: Array[Byte] = Array[Byte](-61, -65)) extends AvroSerializeable with Defaults {
   type J = JDefaultTest
   override def toAvro: JDefaultTest = {
     new JDefaultTest(suit match {

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/NestedProtocol.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/NestedProtocol.scala
@@ -29,7 +29,7 @@ final object Level2 {
   }
 }
 
-final case class Level1(level2: Level2) extends AvroSerializeable with NestedProtocol {
+final case class Level1(level2: example.idl.Level2) extends AvroSerializeable with NestedProtocol {
   type J = JLevel1
   override def toAvro: JLevel1 = {
     new JLevel1(level2.toAvro)
@@ -49,7 +49,7 @@ final object Level1 {
   }
 }
 
-final case class Level0(level1: Level1) extends AvroSerializeable with NestedProtocol {
+final case class Level0(level1: example.idl.Level1) extends AvroSerializeable with NestedProtocol {
   type J = JLevel0
   override def toAvro: JLevel0 = {
     new JLevel0(level1.toAvro)

--- a/avrohugger-core/src/test/expected/scavro/example/idl/model/Recursive.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/idl/model/Recursive.scala
@@ -7,7 +7,7 @@ import org.oedura.scavro.{AvroMetadata, AvroReader, AvroSerializeable}
 
 import example.idl.{Recursive => JRecursive}
 
-final case class Recursive(name: String, recursive: Option[Recursive]) extends AvroSerializeable {
+final case class Recursive(name: String, recursive: Option[example.idl.Recursive]) extends AvroSerializeable {
   type J = JRecursive
   override def toAvro: JRecursive = {
     new JRecursive(name, recursive match {

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashOuter.scala
@@ -9,7 +9,7 @@ import example.avro.{ClashInner => JClashInner, ClashOuter => JClashOuter}
 
 import scala.jdk.CollectionConverters._
 
-final case class ClashOuter(inner: Option[Array[Option[ClashInner]]]) extends AvroSerializeable {
+final case class ClashOuter(inner: Option[Array[Option[example.avro.ClashInner]]]) extends AvroSerializeable {
   type J = JClashOuter
   override def toAvro: JClashOuter = {
     new JClashOuter(inner match {

--- a/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
+++ b/avrohugger-core/src/test/expected/scavro/example/model/ClashRecord.scala
@@ -9,7 +9,7 @@ import example.avro.{ClashInner => JClashInner, ClashOuter => JClashOuter, Clash
 
 import scala.jdk.CollectionConverters._
 
-final case class ClashRecord(some: Int, outer: ClashOuter, id: Int) extends AvroSerializeable {
+final case class ClashRecord(some: Int, outer: example.avro.ClashOuter, id: Int) extends AvroSerializeable {
   type J = JClashRecord
   override def toAvro: JClashRecord = {
     new JClashRecord(some, outer.toAvro, id)

--- a/avrohugger-core/src/test/expected/specific/com/countries/Country.scala
+++ b/avrohugger-core/src/test/expected/specific/com/countries/Country.scala
@@ -1,0 +1,76 @@
+/** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
+package com.countries
+
+import scala.annotation.switch
+
+import com.europe.City
+
+import com.america.City
+
+final case class Country(var key: Option[String] = None, var paris: Option[com.europe.City] = None, var london: Option[com.europe.City] = None, var newYork: Option[com.america.City] = None) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(None, None, None, None)
+  def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {
+        key match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case 1 => {
+        paris match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case 2 => {
+        london match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case 3 => {
+        newYork match {
+          case Some(x) => x
+          case None => null
+        }
+      }.asInstanceOf[AnyRef]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+  def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this.key = {
+        value match {
+          case null => None
+          case _ => Some(value.toString)
+        }
+      }.asInstanceOf[Option[String]]
+      case 1 => this.paris = {
+        value match {
+          case null => None
+          case _ => Some(value)
+        }
+      }.asInstanceOf[Option[com.europe.City]]
+      case 2 => this.london = {
+        value match {
+          case null => None
+          case _ => Some(value)
+        }
+      }.asInstanceOf[Option[com.europe.City]]
+      case 3 => this.newYork = {
+        value match {
+          case null => None
+          case _ => Some(value)
+        }
+      }.asInstanceOf[Option[com.america.City]]
+      case _ => new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+    ()
+  }
+  def getSchema: org.apache.avro.Schema = Country.SCHEMA$
+}
+
+object Country {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Country\",\"namespace\":\"com.countries\",\"fields\":[{\"name\":\"key\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"paris\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"City\",\"namespace\":\"com.europe\",\"fields\":[{\"name\":\"key\",\"type\":\"string\",\"default\":\"Paris\"}]}],\"default\":null},{\"name\":\"london\",\"type\":[\"null\",\"com.europe.City\"],\"default\":null},{\"name\":\"newYork\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"City\",\"namespace\":\"com.america\",\"fields\":[{\"name\":\"name\",\"type\":\"string\",\"default\":\"Paris\"}]}],\"default\":null}]}")
+}

--- a/avrohugger-core/src/test/expected/specific/example/idl/NestedProtocol.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/NestedProtocol.scala
@@ -31,7 +31,7 @@ final object Level2 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Level2\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}")
 }
 
-final case class Level1(var level2: Level2) extends org.apache.avro.specific.SpecificRecordBase with NestedProtocol {
+final case class Level1(var level2: example.idl.Level2) extends org.apache.avro.specific.SpecificRecordBase with NestedProtocol {
   def this() = this(new Level2)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -45,7 +45,7 @@ final case class Level1(var level2: Level2) extends org.apache.avro.specific.Spe
     (field$: @switch) match {
       case 0 => this.level2 = {
         value
-      }.asInstanceOf[Level2]
+      }.asInstanceOf[example.idl.Level2]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -57,7 +57,7 @@ final object Level1 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Level1\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"level2\",\"type\":{\"type\":\"record\",\"name\":\"Level2\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"}]}}]}")
 }
 
-final case class Level0(var level1: Level1) extends org.apache.avro.specific.SpecificRecordBase with NestedProtocol {
+final case class Level0(var level1: example.idl.Level1) extends org.apache.avro.specific.SpecificRecordBase with NestedProtocol {
   def this() = this(new Level1)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -71,7 +71,7 @@ final case class Level0(var level1: Level1) extends org.apache.avro.specific.Spe
     (field$: @switch) match {
       case 0 => this.level1 = {
         value
-      }.asInstanceOf[Level1]
+      }.asInstanceOf[example.idl.Level1]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-core/src/test/expected/specific/example/idl/Recursive.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/Recursive.scala
@@ -3,7 +3,7 @@ package example.idl
 
 import scala.annotation.switch
 
-final case class Recursive(var name: String, var recursive: Option[Recursive]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class Recursive(var name: String, var recursive: Option[example.idl.Recursive]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this("", None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -29,7 +29,7 @@ final case class Recursive(var name: String, var recursive: Option[Recursive]) e
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Recursive]]
+      }.asInstanceOf[Option[example.idl.Recursive]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-core/src/test/expected/specific/example/idl/WithShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/specific/example/idl/WithShapelessCoproduct.scala
@@ -81,7 +81,7 @@ object Event4 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Event4\",\"namespace\":\"example.idl\",\"fields\":[]}")
 }
 
-final case class ShouldRenderAsOption(var value: Option[Event1]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOption(var value: Option[example.idl.Event1]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -101,7 +101,7 @@ final case class ShouldRenderAsOption(var value: Option[Event1]) extends org.apa
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Event1]]
+      }.asInstanceOf[Option[example.idl.Event1]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -113,7 +113,7 @@ object ShouldRenderAsOption {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOption\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsOption2(var value: Option[Event1]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOption2(var value: Option[example.idl.Event1]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -133,7 +133,7 @@ final case class ShouldRenderAsOption2(var value: Option[Event1]) extends org.ap
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Event1]]
+      }.asInstanceOf[Option[example.idl.Event1]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -145,7 +145,7 @@ object ShouldRenderAsOption2 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOption2\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},\"null\"]}]}")
 }
 
-final case class ShouldRenderAsOptionEither(var value: Option[Either[Event1, Event2]]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOptionEither(var value: Option[Either[example.idl.Event1, example.idl.Event2]]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -165,7 +165,7 @@ final case class ShouldRenderAsOptionEither(var value: Option[Either[Event1, Eve
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Either[Event1, Event2]]]
+      }.asInstanceOf[Option[Either[example.idl.Event1, example.idl.Event2]]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -177,7 +177,7 @@ object ShouldRenderAsOptionEither {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOptionEither\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsOptionEither2(var value: Option[Either[Event1, Event2]]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOptionEither2(var value: Option[Either[example.idl.Event1, example.idl.Event2]]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -197,7 +197,7 @@ final case class ShouldRenderAsOptionEither2(var value: Option[Either[Event1, Ev
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Either[Event1, Event2]]]
+      }.asInstanceOf[Option[Either[example.idl.Event1, example.idl.Event2]]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -209,7 +209,7 @@ object ShouldRenderAsOptionEither2 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOptionEither2\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},\"null\",{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsOptionEither3(var value: Option[Either[Event1, Event2]]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOptionEither3(var value: Option[Either[example.idl.Event1, example.idl.Event2]]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -229,7 +229,7 @@ final case class ShouldRenderAsOptionEither3(var value: Option[Either[Event1, Ev
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Either[Event1, Event2]]]
+      }.asInstanceOf[Option[Either[example.idl.Event1, example.idl.Event2]]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -241,7 +241,7 @@ object ShouldRenderAsOptionEither3 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOptionEither3\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]},\"null\"]}]}")
 }
 
-final case class ShouldRenderAsOptionCoproduct(var value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOptionCoproduct(var value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -261,7 +261,7 @@ final case class ShouldRenderAsOptionCoproduct(var value: Option[Event1 :+: Even
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Event1 :+: Event2 :+: Event3 :+: CNil]]
+      }.asInstanceOf[Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -273,7 +273,7 @@ object ShouldRenderAsOptionCoproduct {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOptionCoproduct\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event3\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsOptionCoproduct2(var value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOptionCoproduct2(var value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -293,7 +293,7 @@ final case class ShouldRenderAsOptionCoproduct2(var value: Option[Event1 :+: Eve
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Event1 :+: Event2 :+: Event3 :+: CNil]]
+      }.asInstanceOf[Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -305,7 +305,7 @@ object ShouldRenderAsOptionCoproduct2 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOptionCoproduct2\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event3\",\"fields\":[]},\"null\"]}]}")
 }
 
-final case class ShouldRenderAsOptionCoproduct3(var value: Option[Event1 :+: Event2 :+: Event3 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsOptionCoproduct3(var value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(None)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -325,7 +325,7 @@ final case class ShouldRenderAsOptionCoproduct3(var value: Option[Event1 :+: Eve
           case null => None
           case _ => Some(value)
         }
-      }.asInstanceOf[Option[Event1 :+: Event2 :+: Event3 :+: CNil]]
+      }.asInstanceOf[Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -337,7 +337,7 @@ object ShouldRenderAsOptionCoproduct3 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsOptionCoproduct3\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]},\"null\",{\"type\":\"record\",\"name\":\"Event3\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsEither(var value: Either[Event1, Event2]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsEither(var value: Either[example.idl.Event1, example.idl.Event2]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(Left(new Event1))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -351,7 +351,7 @@ final case class ShouldRenderAsEither(var value: Either[Event1, Event2]) extends
     (field$: @switch) match {
       case 0 => this.value = {
         value
-      }.asInstanceOf[Either[Event1, Event2]]
+      }.asInstanceOf[Either[example.idl.Event1, example.idl.Event2]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -363,7 +363,7 @@ object ShouldRenderAsEither {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsEither\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsCoproduct(var value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsCoproduct(var value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -377,7 +377,7 @@ final case class ShouldRenderAsCoproduct(var value: Event1 :+: Event2 :+: Event3
     (field$: @switch) match {
       case 0 => this.value = {
         value
-      }.asInstanceOf[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil]
+      }.asInstanceOf[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()
@@ -389,7 +389,7 @@ object ShouldRenderAsCoproduct {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"ShouldRenderAsCoproduct\",\"namespace\":\"example.idl\",\"fields\":[{\"name\":\"value\",\"type\":[{\"type\":\"record\",\"name\":\"Event1\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event2\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event3\",\"fields\":[]},{\"type\":\"record\",\"name\":\"Event4\",\"fields\":[]}]}]}")
 }
 
-final case class ShouldRenderAsCoproduct2(var value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
+final case class ShouldRenderAsCoproduct2(var value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -403,7 +403,7 @@ final case class ShouldRenderAsCoproduct2(var value: Event1 :+: Event2 :+: Event
     (field$: @switch) match {
       case 0 => this.value = {
         value
-      }.asInstanceOf[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil]
+      }.asInstanceOf[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithOptionShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithOptionShapelessCoproduct.scala
@@ -11,24 +11,24 @@ final case class Event3()
 
 final case class Event4()
 
-final case class ShouldRenderAsOption1(value: Option[Event1])
+final case class ShouldRenderAsOption1(value: Option[example.idl.Event1])
 
-final case class ShouldRenderAsOption2(value: Option[Event1])
+final case class ShouldRenderAsOption2(value: Option[example.idl.Event1])
 
-final case class ShouldRenderAsCoproduct3(value: Option[Event1 :+: Event2 :+: CNil])
+final case class ShouldRenderAsCoproduct3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil])
 
-final case class ShouldRenderAsCoproduct4(value: Option[Event1 :+: Event2 :+: CNil])
+final case class ShouldRenderAsCoproduct4(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil])
 
-final case class ShouldRenderAsCoproduct5(value: Option[Event1 :+: Event2 :+: CNil])
+final case class ShouldRenderAsCoproduct5(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil])
 
-final case class ShouldRenderAsCoproduct6(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsCoproduct6(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsCoproduct7(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsCoproduct7(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsCoproduct8(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsCoproduct8(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsCoproduct9(value: Event1 :+: Event2 :+: CNil)
+final case class ShouldRenderAsCoproduct9(value: example.idl.Event1 :+: example.idl.Event2 :+: CNil)
 
-final case class ShouldRenderAsCoproduct10(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil)
+final case class ShouldRenderAsCoproduct10(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil)
 
-final case class ShouldRenderAsCoproduct11(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil)
+final case class ShouldRenderAsCoproduct11(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil)

--- a/avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithOptionalShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/AllUnionsWithOptionalShapelessCoproduct.scala
@@ -11,24 +11,24 @@ final case class Event3()
 
 final case class Event4()
 
-final case class ShouldRenderAsCoproduct(value: Option[Event1 :+: CNil])
+final case class ShouldRenderAsCoproduct(value: Option[example.idl.Event1 :+: CNil])
 
-final case class ShouldRenderAsCoproduct2(value: Option[Event1 :+: CNil])
+final case class ShouldRenderAsCoproduct2(value: Option[example.idl.Event1 :+: CNil])
 
-final case class ShouldRenderAsCoproduct3(value: Option[Event1 :+: Event2 :+: CNil])
+final case class ShouldRenderAsCoproduct3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil])
 
-final case class ShouldRenderAsCoproduct4(value: Option[Event1 :+: Event2 :+: CNil])
+final case class ShouldRenderAsCoproduct4(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil])
 
-final case class ShouldRenderAsCoproduct5(value: Option[Event1 :+: Event2 :+: CNil])
+final case class ShouldRenderAsCoproduct5(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil])
 
-final case class ShouldRenderAsCoproduct6(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsCoproduct6(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsCoproduct7(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsCoproduct7(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsCoproduct8(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsCoproduct8(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsCoproduct9(value: Event1 :+: Event2 :+: CNil)
+final case class ShouldRenderAsCoproduct9(value: example.idl.Event1 :+: example.idl.Event2 :+: CNil)
 
-final case class ShouldRenderAsCoproduct10(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil)
+final case class ShouldRenderAsCoproduct10(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil)
 
-final case class ShouldRenderAsCoproduct11(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil)
+final case class ShouldRenderAsCoproduct11(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil)

--- a/avrohugger-core/src/test/expected/standard/example/idl/Defaults.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Defaults.scala
@@ -10,4 +10,4 @@ final object DefaultEnum extends Enumeration with Defaults {
 
 final case class Embedded(inner: Int) extends Defaults
 
-final case class DefaultTest(suit: DefaultEnum.Value = DefaultEnum.SPADES, number: Int = 0, str: String = "str", optionString: Option[String] = None, optionStringValue: Option[String] = Some("default"), embedded: Embedded = new Embedded(1), defaultArray: Seq[Int] = Seq(1, 3, 4, 5), optionalEnum: Option[DefaultEnum.Value] = None, defaultMap: Map[String, String] = Map("Hello" -> "world", "Merry" -> "Christmas"), byt: Array[Byte] = Array[Byte](-61, -65)) extends Defaults
+final case class DefaultTest(suit: DefaultEnum.Value = DefaultEnum.SPADES, number: Int = 0, str: String = "str", optionString: Option[String] = None, optionStringValue: Option[String] = Some("default"), embedded: example.idl.Embedded = new Embedded(1), defaultArray: Seq[Int] = Seq(1, 3, 4, 5), optionalEnum: Option[DefaultEnum.Value] = None, defaultMap: Map[String, String] = Map("Hello" -> "world", "Merry" -> "Christmas"), byt: Array[Byte] = Array[Byte](-61, -65)) extends Defaults

--- a/avrohugger-core/src/test/expected/standard/example/idl/NestedProtocol.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/NestedProtocol.scala
@@ -5,6 +5,6 @@ sealed trait NestedProtocol extends Product with Serializable
 
 final case class Level2(name: String) extends NestedProtocol
 
-final case class Level1(level2: Level2) extends NestedProtocol
+final case class Level1(level2: example.idl.Level2) extends NestedProtocol
 
-final case class Level0(level1: Level1) extends NestedProtocol
+final case class Level0(level1: example.idl.Level1) extends NestedProtocol

--- a/avrohugger-core/src/test/expected/standard/example/idl/Recursive.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/Recursive.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.idl
 
-final case class Recursive(name: String, recursive: Option[Recursive])
+final case class Recursive(name: String, recursive: Option[example.idl.Recursive])

--- a/avrohugger-core/src/test/expected/standard/example/idl/UnionsOptionDefaultParamsValues.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/UnionsOptionDefaultParamsValues.scala
@@ -21,30 +21,30 @@ final case class Event8()
 
 final case class Event9()
 
-final case class ShouldRenderAsOption(value: Option[Event1] = None)
+final case class ShouldRenderAsOption(value: Option[example.idl.Event1] = None)
 
-final case class ShouldRenderAsOption2(value: Option[Event1] = Some(new Event1(0)))
+final case class ShouldRenderAsOption2(value: Option[example.idl.Event1] = Some(new Event1(0)))
 
-final case class ShouldRenderAsOption3(value: Option[Event1 :+: Event2 :+: CNil] = None)
+final case class ShouldRenderAsOption3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil] = None)
 
-final case class ShouldRenderAsOption4(value: Option[Event1 :+: Event2 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: CNil](new Event1(1))))
+final case class ShouldRenderAsOption4(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: CNil](new Event1(1))))
 
-final case class ShouldRenderAsOption5(value: Option[Event1 :+: Event2 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: CNil](new Event1(2))))
+final case class ShouldRenderAsOption5(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: CNil](new Event1(2))))
 
-final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = None)
+final case class ShouldRenderAsOptionCoproduct(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = None)
 
-final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(3))))
+final case class ShouldRenderAsOptionCoproduct2(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(3))))
 
-final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(4))))
+final case class ShouldRenderAsOptionCoproduct3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(4))))
 
-final case class ShouldRenderAsCoproduct1(value: Event1 :+: Event2 :+: CNil = Coproduct[Event1 :+: Event2 :+: CNil](new Event1(5)))
+final case class ShouldRenderAsCoproduct1(value: example.idl.Event1 :+: example.idl.Event2 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: CNil](new Event1(5)))
 
-final case class ShouldRenderAsCoproduct2(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1(6)))
+final case class ShouldRenderAsCoproduct2(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil](new Event1(6)))
 
-final case class CopX(value: Event1 :+: Event2 :+: Event3 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(7)))
+final case class CopX(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(7)))
 
-final case class CopY(value: Event4 :+: Event5 :+: Event6 :+: CNil = Coproduct[Event4 :+: Event5 :+: Event6 :+: CNil](new Event4(8)))
+final case class CopY(value: example.idl.Event4 :+: example.idl.Event5 :+: example.idl.Event6 :+: CNil = Coproduct[example.idl.Event4 :+: example.idl.Event5 :+: example.idl.Event6 :+: CNil](new Event4(8)))
 
-final case class CopZ(value: Event7 :+: Event8 :+: Event9 :+: CNil = Coproduct[Event7 :+: Event8 :+: Event9 :+: CNil](new Event7(9)))
+final case class CopZ(value: example.idl.Event7 :+: example.idl.Event8 :+: example.idl.Event9 :+: CNil = Coproduct[example.idl.Event7 :+: example.idl.Event8 :+: example.idl.Event9 :+: CNil](new Event7(9)))
 
-final case class ShouldRenderAsCoproductOfCoproduct(value: CopX :+: CopY :+: CopZ :+: CNil = Coproduct[CopX :+: CopY :+: CopZ :+: CNil](new CopX(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(10)))))
+final case class ShouldRenderAsCoproductOfCoproduct(value: example.idl.CopX :+: example.idl.CopY :+: example.idl.CopZ :+: CNil = Coproduct[example.idl.CopX :+: example.idl.CopY :+: example.idl.CopZ :+: CNil](new CopX(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(10)))))

--- a/avrohugger-core/src/test/expected/standard/example/idl/UnionsOptionEitherDefaultParamsValues.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/UnionsOptionEitherDefaultParamsValues.scala
@@ -21,30 +21,30 @@ final case class Event8()
 
 final case class Event9()
 
-final case class ShouldRenderAsOption(value: Option[Event1] = None)
+final case class ShouldRenderAsOption(value: Option[example.idl.Event1] = None)
 
-final case class ShouldRenderAsOption2(value: Option[Event1] = Some(new Event1(0)))
+final case class ShouldRenderAsOption2(value: Option[example.idl.Event1] = Some(new Event1(0)))
 
-final case class ShouldRenderAsOptionEither(value: Option[Either[Event1, Event2]] = None)
+final case class ShouldRenderAsOptionEither(value: Option[Either[example.idl.Event1, example.idl.Event2]] = None)
 
-final case class ShouldRenderAsOptionEither2(value: Option[Either[Event1, Event2]] = Some(Left(new Event1(1))))
+final case class ShouldRenderAsOptionEither2(value: Option[Either[example.idl.Event1, example.idl.Event2]] = Some(Left(new Event1(1))))
 
-final case class ShouldRenderAsOptionEither3(value: Option[Either[Event1, Event2]] = Some(Left(new Event1(2))))
+final case class ShouldRenderAsOptionEither3(value: Option[Either[example.idl.Event1, example.idl.Event2]] = Some(Left(new Event1(2))))
 
-final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = None)
+final case class ShouldRenderAsOptionCoproduct(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = None)
 
-final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(3))))
+final case class ShouldRenderAsOptionCoproduct2(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(3))))
 
-final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(4))))
+final case class ShouldRenderAsOptionCoproduct3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(4))))
 
-final case class ShouldRenderAsEither(value: Either[Event1, Event2] = Left(new Event1(5)))
+final case class ShouldRenderAsEither(value: Either[example.idl.Event1, example.idl.Event2] = Left(new Event1(5)))
 
-final case class ShouldRenderAsCoproduct(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1(6)))
+final case class ShouldRenderAsCoproduct(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil](new Event1(6)))
 
-final case class CopX(value: Event1 :+: Event2 :+: Event3 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(7)))
+final case class CopX(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(7)))
 
-final case class CopY(value: Event4 :+: Event5 :+: Event6 :+: CNil = Coproduct[Event4 :+: Event5 :+: Event6 :+: CNil](new Event4(8)))
+final case class CopY(value: example.idl.Event4 :+: example.idl.Event5 :+: example.idl.Event6 :+: CNil = Coproduct[example.idl.Event4 :+: example.idl.Event5 :+: example.idl.Event6 :+: CNil](new Event4(8)))
 
-final case class CopZ(value: Event7 :+: Event8 :+: Event9 :+: CNil = Coproduct[Event7 :+: Event8 :+: Event9 :+: CNil](new Event7(9)))
+final case class CopZ(value: example.idl.Event7 :+: example.idl.Event8 :+: example.idl.Event9 :+: CNil = Coproduct[example.idl.Event7 :+: example.idl.Event8 :+: example.idl.Event9 :+: CNil](new Event7(9)))
 
-final case class ShouldRenderAsCoproductOfCoproduct(value: CopX :+: CopY :+: CopZ :+: CNil = Coproduct[CopX :+: CopY :+: CopZ :+: CNil](new CopX(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(10)))))
+final case class ShouldRenderAsCoproductOfCoproduct(value: example.idl.CopX :+: example.idl.CopY :+: example.idl.CopZ :+: CNil = Coproduct[example.idl.CopX :+: example.idl.CopY :+: example.idl.CopZ :+: CNil](new CopX(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(10)))))

--- a/avrohugger-core/src/test/expected/standard/example/idl/UnionsOptionalDefaultParamsValues.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/UnionsOptionalDefaultParamsValues.scala
@@ -21,30 +21,30 @@ final case class Event8()
 
 final case class Event9()
 
-final case class ShouldRenderAsOption(value: Option[Event1 :+: CNil] = None)
+final case class ShouldRenderAsOption(value: Option[example.idl.Event1 :+: CNil] = None)
 
-final case class ShouldRenderAsOption2(value: Option[Event1 :+: CNil] = Some(Coproduct[Event1 :+: CNil](new Event1(0))))
+final case class ShouldRenderAsOption2(value: Option[example.idl.Event1 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: CNil](new Event1(0))))
 
-final case class ShouldRenderAsOption3(value: Option[Event1 :+: Event2 :+: CNil] = None)
+final case class ShouldRenderAsOption3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil] = None)
 
-final case class ShouldRenderAsOption4(value: Option[Event1 :+: Event2 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: CNil](new Event1(1))))
+final case class ShouldRenderAsOption4(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: CNil](new Event1(1))))
 
-final case class ShouldRenderAsOption5(value: Option[Event1 :+: Event2 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: CNil](new Event1(2))))
+final case class ShouldRenderAsOption5(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: CNil](new Event1(2))))
 
-final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = None)
+final case class ShouldRenderAsOptionCoproduct(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = None)
 
-final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(3))))
+final case class ShouldRenderAsOptionCoproduct2(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(3))))
 
-final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil] = Some(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(4))))
+final case class ShouldRenderAsOptionCoproduct3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil] = Some(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(4))))
 
-final case class ShouldRenderAsCoproduct1(value: Event1 :+: Event2 :+: CNil = Coproduct[Event1 :+: Event2 :+: CNil](new Event1(5)))
+final case class ShouldRenderAsCoproduct1(value: example.idl.Event1 :+: example.idl.Event2 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: CNil](new Event1(5)))
 
-final case class ShouldRenderAsCoproduct2(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil](new Event1(6)))
+final case class ShouldRenderAsCoproduct2(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil](new Event1(6)))
 
-final case class CopX(value: Event1 :+: Event2 :+: Event3 :+: CNil = Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(7)))
+final case class CopX(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil = Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(7)))
 
-final case class CopY(value: Event4 :+: Event5 :+: Event6 :+: CNil = Coproduct[Event4 :+: Event5 :+: Event6 :+: CNil](new Event4(8)))
+final case class CopY(value: example.idl.Event4 :+: example.idl.Event5 :+: example.idl.Event6 :+: CNil = Coproduct[example.idl.Event4 :+: example.idl.Event5 :+: example.idl.Event6 :+: CNil](new Event4(8)))
 
-final case class CopZ(value: Event7 :+: Event8 :+: Event9 :+: CNil = Coproduct[Event7 :+: Event8 :+: Event9 :+: CNil](new Event7(9)))
+final case class CopZ(value: example.idl.Event7 :+: example.idl.Event8 :+: example.idl.Event9 :+: CNil = Coproduct[example.idl.Event7 :+: example.idl.Event8 :+: example.idl.Event9 :+: CNil](new Event7(9)))
 
-final case class ShouldRenderAsCoproductOfCoproduct(value: CopX :+: CopY :+: CopZ :+: CNil = Coproduct[CopX :+: CopY :+: CopZ :+: CNil](new CopX(Coproduct[Event1 :+: Event2 :+: Event3 :+: CNil](new Event1(10)))))
+final case class ShouldRenderAsCoproductOfCoproduct(value: example.idl.CopX :+: example.idl.CopY :+: example.idl.CopZ :+: CNil = Coproduct[example.idl.CopX :+: example.idl.CopY :+: example.idl.CopZ :+: CNil](new CopX(Coproduct[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil](new Event1(10)))))

--- a/avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/WithShapelessCoproduct.scala
@@ -11,24 +11,24 @@ final case class Event3()
 
 final case class Event4()
 
-final case class ShouldRenderAsOption(value: Option[Event1])
+final case class ShouldRenderAsOption(value: Option[example.idl.Event1])
 
-final case class ShouldRenderAsOption2(value: Option[Event1])
+final case class ShouldRenderAsOption2(value: Option[example.idl.Event1])
 
-final case class ShouldRenderAsOptionEither(value: Option[Either[Event1, Event2]])
+final case class ShouldRenderAsOptionEither(value: Option[Either[example.idl.Event1, example.idl.Event2]])
 
-final case class ShouldRenderAsOptionEither2(value: Option[Either[Event1, Event2]])
+final case class ShouldRenderAsOptionEither2(value: Option[Either[example.idl.Event1, example.idl.Event2]])
 
-final case class ShouldRenderAsOptionEither3(value: Option[Either[Event1, Event2]])
+final case class ShouldRenderAsOptionEither3(value: Option[Either[example.idl.Event1, example.idl.Event2]])
 
-final case class ShouldRenderAsOptionCoproduct(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsOptionCoproduct(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsOptionCoproduct2(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsOptionCoproduct2(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsOptionCoproduct3(value: Option[Event1 :+: Event2 :+: Event3 :+: CNil])
+final case class ShouldRenderAsOptionCoproduct3(value: Option[example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: CNil])
 
-final case class ShouldRenderAsEither(value: Either[Event1, Event2])
+final case class ShouldRenderAsEither(value: Either[example.idl.Event1, example.idl.Event2])
 
-final case class ShouldRenderAsCoproduct(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil)
+final case class ShouldRenderAsCoproduct(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil)
 
-final case class ShouldRenderAsCoproduct2(value: Event1 :+: Event2 :+: Event3 :+: Event4 :+: CNil)
+final case class ShouldRenderAsCoproduct2(value: example.idl.Event1 :+: example.idl.Event2 :+: example.idl.Event3 :+: example.idl.Event4 :+: CNil)

--- a/avrohugger-core/src/test/expected/standard/example/idl/WithoutShapelessCoproduct.scala
+++ b/avrohugger-core/src/test/expected/standard/example/idl/WithoutShapelessCoproduct.scala
@@ -9,14 +9,14 @@ final case class Event3()
 
 final case class Event4()
 
-final case class ShouldRenderAsOption(value: Option[Event1])
+final case class ShouldRenderAsOption(value: Option[example.idl.Event1])
 
-final case class ShouldRenderAsOption2(value: Option[Event1])
+final case class ShouldRenderAsOption2(value: Option[example.idl.Event1])
 
-final case class ShouldRenderAsOptionEither(value: Option[Either[Event1, Event2]])
+final case class ShouldRenderAsOptionEither(value: Option[Either[example.idl.Event1, example.idl.Event2]])
 
-final case class ShouldRenderAsOptionEither2(value: Option[Either[Event1, Event2]])
+final case class ShouldRenderAsOptionEither2(value: Option[Either[example.idl.Event1, example.idl.Event2]])
 
-final case class ShouldRenderAsOptionEither3(value: Option[Either[Event1, Event2]])
+final case class ShouldRenderAsOptionEither3(value: Option[Either[example.idl.Event1, example.idl.Event2]])
 
-final case class ShouldRenderAsEither(value: Either[Event1, Event2])
+final case class ShouldRenderAsEither(value: Either[example.idl.Event1, example.idl.Event2])

--- a/avrohugger-core/src/test/expected/standard/example/shanested/foo/HashRecord.scala
+++ b/avrohugger-core/src/test/expected/standard/example/shanested/foo/HashRecord.scala
@@ -3,4 +3,4 @@ package example.shanested.foo
 
 import example.shanested.{Prop, Sha256}
 
-final case class HashRecord(my_hash: Sha256, prop: Prop)
+final case class HashRecord(my_hash: Sha256, prop: example.shanested.Prop)

--- a/avrohugger-core/src/test/scala/specific/SpecificSameRecordNameSpec.scala
+++ b/avrohugger-core/src/test/scala/specific/SpecificSameRecordNameSpec.scala
@@ -1,0 +1,18 @@
+package specific
+
+import avrohugger._
+import avrohugger.format.SpecificRecord
+import org.specs2._
+
+class SpecificSameRecordNameSpec extends mutable.Specification {
+  "a Generator" should {
+    "use the fully qualified name of the records" in {
+      val infile = new java.io.File("avrohugger-core/src/test/avro/SameRecordNameDifferentNamespace.avsc")
+      val gen = new Generator(SpecificRecord)
+      val outDir = gen.defaultOutputDir + "/specific/"
+      gen.fileToFile(infile, outDir)
+      val sourceRecord = scala.io.Source.fromFile(s"$outDir/com/countries/Country.scala").mkString
+      sourceRecord ==== util.Util.readFile("avrohugger-core/src/test/expected/specific/com/countries/Country.scala")
+    }
+  }
+}

--- a/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Player.scala
+++ b/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Player.scala
@@ -3,7 +3,7 @@ package avro.examples.baseball
 
 import scala.annotation.switch
 
-final case class Player(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[Nickname]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class Player(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[avro.examples.baseball.Nickname]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(0, "", "", Seq.empty)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -45,7 +45,7 @@ final case class Player(var number: Int, var first_name: String, var last_name: 
             }).toSeq
           }
         }
-      }.asInstanceOf[Seq[Nickname]]
+      }.asInstanceOf[Seq[avro.examples.baseball.Nickname]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Player_2.13.scala
+++ b/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Player_2.13.scala
@@ -3,7 +3,7 @@ package avro.examples.baseball
 
 import scala.annotation.switch
 
-final case class Player(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[Nickname]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class Player(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[avro.examples.baseball.Nickname]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(0, "", "", Seq.empty)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -45,7 +45,7 @@ final case class Player(var number: Int, var first_name: String, var last_name: 
             }).toSeq
           }
         }
-      }.asInstanceOf[Seq[Nickname]]
+      }.asInstanceOf[Seq[avro.examples.baseball.Nickname]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Wrestler.scala
+++ b/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Wrestler.scala
@@ -3,7 +3,7 @@ package avro.examples.baseball
 
 import scala.annotation.switch
 
-final case class Wrestler(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[Mascot]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class Wrestler(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[avro.examples.baseball.Mascot]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(0, "", "", Seq.empty)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -17,7 +17,7 @@ final case class Wrestler(var number: Int, var first_name: String, var last_name
         last_name
       }.asInstanceOf[AnyRef]
       case 3 => {
-        scala.collection.JavaConverters.bufferAsJavaListConverter({
+        scala.jdk.CollectionConverters.BufferHasAsJava({
           nicknames map { x =>
             x
           }
@@ -40,12 +40,12 @@ final case class Wrestler(var number: Int, var first_name: String, var last_name
       case 3 => this.nicknames = {
         value match {
           case (array: java.util.List[_]) => {
-            scala.collection.JavaConverters.asScalaIteratorConverter(array.iterator).asScala.map({ x =>
+            scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ x =>
               x
             }).toSeq
           }
         }
-      }.asInstanceOf[Seq[Mascot]]
+      }.asInstanceOf[Seq[avro.examples.baseball.Mascot]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Wrestler_2.13.scala
+++ b/avrohugger-tools/src/test/compiler/output-specific/avro/examples/baseball/Wrestler_2.13.scala
@@ -3,7 +3,7 @@ package avro.examples.baseball
 
 import scala.annotation.switch
 
-final case class Wrestler(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[Mascot]) extends org.apache.avro.specific.SpecificRecordBase {
+final case class Wrestler(var number: Int, var first_name: String, var last_name: String, var nicknames: Seq[avro.examples.baseball.Mascot]) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(0, "", "", Seq.empty)
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
@@ -45,7 +45,7 @@ final case class Wrestler(var number: Int, var first_name: String, var last_name
             }).toSeq
           }
         }
-      }.asInstanceOf[Seq[Mascot]]
+      }.asInstanceOf[Seq[avro.examples.baseball.Mascot]]
       case _ => new org.apache.avro.AvroRuntimeException("Bad index")
     }
     ()

--- a/avrohugger-tools/src/test/compiler/output/Pilot.scala
+++ b/avrohugger-tools/src/test/compiler/output/Pilot.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package avro.examples.flight
 
-final case class Pilot(number: Int, first_name: String, last_name: String, nicknames: Seq[Handle])
+final case class Pilot(number: Int, first_name: String, last_name: String, nicknames: Seq[avro.examples.flight.Handle])

--- a/avrohugger-tools/src/test/compiler/output/avro/examples/baseball/Wrestler.scala
+++ b/avrohugger-tools/src/test/compiler/output/avro/examples/baseball/Wrestler.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package avro.examples.baseball
 
-final case class Wrestler(number: Int, first_name: String, last_name: String, nicknames: Seq[Mascot])
+final case class Wrestler(number: Int, first_name: String, last_name: String, nicknames: Seq[avro.examples.baseball.Mascot])

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val avroVersion = "1.11.1"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "1.3.0",
+  version := "1.3.1",
   ThisBuild / versionScheme := Some("semver-spec"),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
   Test / scalacOptions ++= Seq("-Yrangepos"),
@@ -30,12 +30,12 @@ lazy val commonSettings = Seq(
   libraryDependencies += "org.specs2" %% "specs2-core" % "4.16.1" % "test",
   publishMavenStyle := true,
   Test / publishArtifact := false,
-  publishTo := Some(
+  publishTo := {
   if (isSnapshot.value)
-    Opts.resolver.sonatypeSnapshots
+    Opts.resolver.sonatypeOssSnapshots.headOption
   else
-    Opts.resolver.sonatypeStaging
-  ),
+    Some(Opts.resolver.sonatypeStaging)
+  },
   pomIncludeRepository := { _ => false },
   licenses := Seq("Apache 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
   homepage := Some(url("https://github.com/julianpeeters/avrohugger")),


### PR DESCRIPTION
As mentioned in issues: https://github.com/julianpeeters/avrohugger/issues/69 and https://github.com/julianpeeters/avrohugger/issues/114. We have come across conflicting the same name in different namespaces with a compile error.

With this pull request, we try to add the full name with the namespace as a type for a record fields.